### PR TITLE
Added extra symbols to "bound_symbols".

### DIFF
--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -420,7 +420,7 @@ def get_word(view, reg):
     return sublime.Region(beg, end)
 
 
-bound_symbols = ["\n", "\t", " ", ";", ":", ",", "\'", "\"", ">", "<"]
+bound_symbols = ["\n", "\t", " ", ";", ":", ",", "\'", "\"", ">", "<", "(", ")"]
 def isInColor(view, sel, col_vars, array_format):
     b = sel.begin()
     if b != sel.end():


### PR DESCRIPTION
Added **"("** and **")"** bounds. This fixes the color highlight
in preproccesors. Without this, first or last hexadecimal
colors in maps, lists, mixins, etc, won't be highlighted.
Like example:

```
$share-option-color: (shr-link: #9D4EBB,
          shr-url: lighten(#9D4EBB,5%),
                      shr-tw: #22BBF5, shr-gplus: #B93116);
```

Here, `shr-gplus` isn't highlighted because their last bound is
an **")"**.
Same happens with color in `lighten(#9D4EBB,5%)`, because their
first bound is an **"("**.
