### PR TITLE
Set UTF-8 encoding on non-binary file open & close to fix issue #131.

### DIFF
--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -38,7 +38,7 @@ def print_error(err):
 # files helpers
 
 def write_file(fl, s):
-    with open(fl, "w") as f:
+    with open(fl, "w", encoding="utf8") as f:
         f.write(s)
 
 def write_bin_file(fl, s):
@@ -46,7 +46,7 @@ def write_bin_file(fl, s):
         f.write(s)
 
 def read_file(fl):
-    with open(fl, "r") as f:
+    with open(fl, "r", encoding="utf8") as f:
         return f.read()
 
 


### PR DESCRIPTION
Fix #131 - Python was assuming platform default encoding for files, causing it to choke on a mismatch. Set to UTF-8.
