### PR TITLE
Added .erb and .haml to file extensions

### DIFF
--- a/ColorHighlighter.sublime-settings
+++ b/ColorHighlighter.sublime-settings
@@ -16,5 +16,5 @@
         "hsl(0, 100%, 100%)",
         "hsla(0, 100%, 100%, 1.0)"
     ],
-    "file_exts": [".css", ".sass", ".scss", ".less", ".styl", ".html", ".js", ".sublime-settings", ".tmTheme"]
+    "file_exts": [".css", ".sass", ".scss", ".less", ".styl", ".html", ".js", ".sublime-settings", ".tmTheme", ".erb", ".haml"]
 }


### PR DESCRIPTION
When developing Ruby (RoR) apps the file extension .erb (eRuby) and .haml are often used for the views and even the css files can contain embedded ruby code. Therefore ColorHighlighter should highlight the color in these files, too.
