### PR TITLE
adding "highlight_all":  false to defaults

### DIFF
--- a/ColorHighlighter.sublime-settings
+++ b/ColorHighlighter.sublime-settings
@@ -7,6 +7,7 @@
     "icons_all": false,
     "default_keybindings": true,
     "convert_util_path" : "convert",
+    "highlight_all": false,
     "color_formats": [
         "white",
         "#FFF", "#FFFF", "#FFFFFF", "#FFFFFFFF",


### PR DESCRIPTION
this option is missing from defaults, and when mentioned in documentation throws off reader.