### PR TITLE
don't activate in view with no file name

### DIFF
--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -1420,7 +1420,7 @@ class ColorHighlighter:
         if fe == "all":
             return True
         if fname is None or fname == "":
-            return True
+            return False
         return os.path.splitext(fname)[1] in fe
 
     def _redraw(self):

--- a/ColorHighlighter.sublime-settings
+++ b/ColorHighlighter.sublime-settings
@@ -62,24 +62,24 @@
         },
         "hex8": {
             "description": "Hex 0xRRGGBBAA color format",
-            "regex": "0x(?P<R>hex2)(?P<G>hex2)(?P<B>hex2)(?P<A>hex2)",
+            "regex": "0x(?P<R>hex2)(?P<G>hex2)(?P<B>hex2)(?P<A>hex2)\\b",
             "white": "0xFFFFFFFF"
         },
         "hex6": {
             "description": "Hex 0xRRGGBB color format",
-            "regex": "0x(?P<R>hex2)(?P<G>hex2)(?P<B>hex2)",
+            "regex": "0x(?P<R>hex2)(?P<G>hex2)(?P<B>hex2)\\b",
             "white": "0xFFFFFF",
             "after": "hex8"
         },
         "hex4": {
             "description": "Hex 0xRGBA color format",
-            "regex": "0x(?P<R>hex1)(?P<G>hex1)(?P<B>hex1)(?P<A>hex1)",
+            "regex": "0x(?P<R>hex1)(?P<G>hex1)(?P<B>hex1)(?P<A>hex1)\\b",
             "white": "0xFFFF",
             "after": "hex6"
         },
         "hex3": {
             "description": "Hex 0xRGB color format",
-            "regex": "0x(?P<R>hex1)(?P<G>hex1)(?P<B>hex1)",
+            "regex": "0x(?P<R>hex1)(?P<G>hex1)(?P<B>hex1)\\b",
             "white": "0xFFF",
             "after": "hex4"
         },


### PR DESCRIPTION
By default, CH is active in all new views that haven't been saved yet, as well as views that don't have a file name associated with them - I'm thinking specifically of [`SublimeREPL`](https://packagecontrol.io/packages/SublimeREPL), but there are likely other examples as well. Here's an example of unwanted highlighting when using the [IPython](http://ipython.org) REPL and plotting with `matplotlib` where the memory address of the resulting object is printed:

<img width="606" src="https://cloud.githubusercontent.com/assets/1776358/11932536/28a498ba-a7c4-11e5-8119-df109367f6b6.png">

and here is an example of a `numpy` array containing 3-item lists:

<img width="538" src="https://cloud.githubusercontent.com/assets/1776358/11932579/81077298-a7c4-11e5-9e65-b61a41e5760d.png">

By simply changing the following code
```python
        if fname is None or fname == "":
            return True
```
to
```python
        if fname is None or fname == "":
            return False
```
we get rid of this problem entirely.