### PR TITLE
Fix gutter icons on light themes

### DIFF
--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -130,7 +130,7 @@ def create_if_not_exists(path):
 ### Theme builder
 
 def region_name(s, is_text):
-    res = "mcol_"
+    res = "mcol mcol_"
     if is_text:
         res += "text_"
     return res + s[1:]


### PR DESCRIPTION
I've looked at this [commit](https://github.com/ggordan/GutterColor/commit/dcddd6dde8b566fb221db1b7812315d9b7511041) and added scope to fix gutter icons on light themes. It works like a charm if your color scheme includes:

```xml
<dict>
	<key>name</key>
	<string>Gutter Color Fix</string>
	<key>scope</key>
	<string>mcol</string>
	<key>settings</key>
	<dict>
		<key>foreground</key>
		<string>#ffffff</string>
	</dict>
</dict>
```

The other code in this [commit](https://github.com/ggordan/GutterColor/commit/dcddd6dde8b566fb221db1b7812315d9b7511041) is related to generating this piece of code in the user's current color scheme. I have been trying to make it work, but unable to do that, I'm not advanced in Python.

You can test it with [Boxy Yesterday](https://github.com/oivva/boxy) color scheme, I've added support of it in the latest release.

Related to #183, #295

