### PR TITLE
Added .stTheme extension

### DIFF
--- a/ColorHighlighter.sublime-settings
+++ b/ColorHighlighter.sublime-settings
@@ -6,7 +6,7 @@
     "ha_icons": false,
     "default_keybindings": true,
     "convert_util_path" : "convert",
-    "file_exts": [".css", ".sass", ".scss", ".less", ".styl", ".html", ".js", ".sublime-settings", ".tmTheme", ".erb", ".haml", ".back", ".py", ".md"],
+    "file_exts": [".css", ".sass", ".scss", ".less", ".styl", ".html", ".js", ".sublime-settings", ".tmTheme", ".stTheme", ".erb", ".haml", ".back", ".py", ".md"],
     "channels": {
         "empty": "",
         "hex2": "[0-9a-fA-F]{2}",


### PR DESCRIPTION
The files with this extension сustomizable color schemes for panels and consoles in Sublime Text 3. For example, see [answer](http://stackoverflow.com/a/10770137/5951529) on Stack Overflow.