### PR TITLE
add json to default list of supported file types

### DIFF
--- a/ColorHighlighter.sublime-settings
+++ b/ColorHighlighter.sublime-settings
@@ -6,7 +6,7 @@
     "ha_icons": false,
     "default_keybindings": true,
     "convert_util_path" : "convert",
-    "file_exts": [".css", ".sass", ".scss", ".less", ".styl", ".html", ".js", ".sublime-settings", ".tmTheme", ".stTheme", ".erb", ".haml", ".back", ".py", ".md"],
+    "file_exts": [".css", ".sass", ".scss", ".less", ".styl", ".html", ".js", ".sublime-settings", ".tmTheme", ".stTheme", ".erb", ".haml", ".back", ".py", ".md", ".json"],
     "channels": {
         "empty": "",
         "hex2": "[0-9a-fA-F]{2}",


### PR DESCRIPTION
Hi

I guess it could be handy to include .json into the default list of supported file types.

cheers
