### PR TITLE
Allow color_variables_files to use project-specific path variables

### DIFF
--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -10,6 +10,10 @@ import threading
 import shutil
 import codecs
 import time
+from string import Template
+
+if int(sublime.version()) < 3000:
+    import build_system_hack
 
 plugin_name = "Color Highlighter"
 
@@ -1229,23 +1233,35 @@ class VarExtractor:
 
     def get_vars(self, view):
         color_vars_files = []
-        if is_st3():
+        if not is_st3():
+            project_settings = build_system_hack.get_project_settings(sublime.active_window())
+            wnd = sublime.active_window()
+        else:
             wnd = view.window()
-            if wnd is not None:
-                pdata = wnd.project_data()
-                if pdata is not None:
-                    color_vars_files = pdata.get("color_variables_files", [])
-                    if type(color_vars_files) is not list:
-                        color_vars_files = [color_vars_files]
-                    color_vars_file = pdata.get("color_variables_file", None)
-                    if color_vars_file is not None:
-                        color_vars_files.append(color_vars_file)
 
-                    for f in color_vars_files:
-                        self.parse_vars_file(f)
+        if wnd is not None:
+            if is_st3():
+                pdata = wnd.project_data()
+            else:
+                pdata = view.settings()
+
+            if pdata is not None:
+                color_vars_files = pdata.get("color_variables_files", [])
+                if type(color_vars_files) is not list:
+                    color_vars_files = [color_vars_files]
+                color_vars_file = pdata.get("color_variables_file", None)
+                if color_vars_file is not None:
+                    color_vars_files.append(color_vars_file)
+
+                for f in color_vars_files:
+                    if is_st3():
+                        self.parse_vars_file(sublime.expand_variables(f, wnd.extract_variables()))
+                    else:
+                        self.parse_vars_file(Template(f).substitute(project_settings))
 
         fn = view.file_name()
         res = {}
+
         if fn is not None:
             self.parse_vars_file(fn)
             self.get_file_vars(fn, res)
@@ -1253,9 +1269,12 @@ class VarExtractor:
             self.parse_vars_view(view)
             self.get_view_vars(view, res)
 
-        if is_st3():
+        if wnd is not None:
             for f in color_vars_files:
-                self.get_file_vars(f, res)
+                if is_st3():
+                    self.get_file_vars(sublime.expand_variables(f, wnd.extract_variables()), res)
+                else:
+                    self.get_file_vars(Template(f).substitute(project_settings), res)
 
         # map text to colors
         for k in res.keys():

--- a/build_system_hack.py
+++ b/build_system_hack.py
@@ -1,0 +1,25 @@
+import sublime_plugin
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+
+RESULTS = None
+HACK_BUILD_SYSTEM = "Packages/Color Highlighter/build_system_hack.sublime-build"
+AUTOMATIC_BUILD_SYSTEM = ""
+
+
+class BuildSystemHackCommand(sublime_plugin.WindowCommand):
+    def run(self, cmd):
+        RESULTS.put(cmd)
+
+
+def get_project_settings(window):
+    global RESULTS
+    try:
+        RESULTS = queue.Queue()  # in case of garbage on RESULTS
+        window.run_command("set_build_system", {"file": HACK_BUILD_SYSTEM})
+        window.run_command("build")
+    finally:
+        window.run_command("set_build_system", {"file": AUTOMATIC_BUILD_SYSTEM})
+    return RESULTS.get(timeout=1.0)

--- a/build_system_hack.sublime-build
+++ b/build_system_hack.sublime-build
@@ -1,0 +1,17 @@
+{
+	"target": "build_system_hack",
+	"cmd": {
+		"file_path": "${file_path}",
+		"file": "${file}",
+		"file_name": "${file_name}",
+		"file_extension": "${file_extension}",
+		"file_base_name": "${file_base_name}",
+		"packages": "${packages}",
+		"project": "${project}",
+		"project_path": "${project_path}",
+		"project_name": "${project_name}",
+		"project_extension": "${project_extension}",
+		"project_base_name": "${project_base_name}",
+		"project_folder": "${project_folder}"
+	}
+}


### PR DESCRIPTION
The SublimeREPL project has a neat hack that uses a sublime-build to define sublime-project variables for relative paths.

Fixes #322.