### PR TITLE
Use .colorhighlighter file for color_variables_files

### DIFF
--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -1244,11 +1244,11 @@ class VarExtractor:
 
                     # If not opened as a project
                     if wnd.project_file_name() is None:
-                        # Path of .sublime-project based on folders path
-                        sublime_project = pdata.get("folders", {})[0]["path"] + "/.sublime-project"
+                        # Path of .colorhighlighter file based on folders path
+                        sublime_project = pdata.get("folders", {})[0]["path"] + "/.colorhighlighter"
                         sublime_project_data = None
 
-                        # If .sublime-project file in path exists
+                        # If .colorhighlighter file file in path exists
                         if os.path.isfile(sublime_project):
                             # Read file
                             with open(sublime_project) as contents:

--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -1242,34 +1242,36 @@ class VarExtractor:
                     if color_vars_file is not None:
                         color_vars_files.append(color_vars_file)
 
-                    # Path of .sublime-project based on folders path
-                    sublime_project = pdata.get("folders", {})[0]["path"] + "/.sublime-project"
-                    sublime_project_data = None
+                    # If not opened as a project
+                    if wnd.project_file_name() is None:
+                        # Path of .sublime-project based on folders path
+                        sublime_project = pdata.get("folders", {})[0]["path"] + "/.sublime-project"
+                        sublime_project_data = None
 
-                    # If .sublime-project file in path exists
-                    if os.path.isfile(sublime_project):
-                        # Read file
-                        with open(sublime_project) as contents:
-                            # Try to parse JSON
-                            try:
-                                sublime_project_data = json.load(contents)
-                            except Exception:
-                                pass
+                        # If .sublime-project file in path exists
+                        if os.path.isfile(sublime_project):
+                            # Read file
+                            with open(sublime_project) as contents:
+                                # Try to parse JSON
+                                try:
+                                    sublime_project_data = json.load(contents)
+                                except Exception:
+                                    pass
 
-                        # If valid JSON
-                        if sublime_project_data is not None:
-                            # If "color_variables_files" key exists
-                            if "color_variables_files" in sublime_project_data:
-                                sublime_project_data_var = sublime_project_data["color_variables_files"]
-                                # If string
-                                if type(sublime_project_data_var) is str:
-                                    color_vars_files.append(sublime_project_data_var)
-                                # If list
-                                elif type(sublime_project_data_var) is list:
-                                    # For each in list
-                                    for i in sublime_project_data_var:
-                                        # Append to color_vars_files
-                                        color_vars_files.append(sublime_project_data_var[i])
+                            # If valid JSON
+                            if sublime_project_data is not None:
+                                # If "color_variables_files" key exists
+                                if "color_variables_files" in sublime_project_data:
+                                    sublime_project_data_var = sublime_project_data["color_variables_files"]
+                                    # If string
+                                    if type(sublime_project_data_var) is str:
+                                        color_vars_files.append(sublime_project_data_var)
+                                    # If list
+                                    elif type(sublime_project_data_var) is list:
+                                        # For each in list
+                                        for i in sublime_project_data_var:
+                                            # Append to color_vars_files
+                                            color_vars_files.append(sublime_project_data_var[i])
 
                     for f in color_vars_files:
                         self.parse_vars_file(f)

--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -10,6 +10,7 @@ import threading
 import shutil
 import codecs
 import time
+import json
 
 plugin_name = "Color Highlighter"
 
@@ -1240,6 +1241,35 @@ class VarExtractor:
                     color_vars_file = pdata.get("color_variables_file", None)
                     if color_vars_file is not None:
                         color_vars_files.append(color_vars_file)
+
+                    # Path of .sublime-project based on folders path
+                    sublime_project = pdata.get("folders", {})[0]["path"] + "/.sublime-project"
+                    sublime_project_data = None
+
+                    # If .sublime-project file in path exists
+                    if os.path.isfile(sublime_project):
+                        # Read file
+                        with open(sublime_project) as contents:
+                            # Try to parse JSON
+                            try:
+                                sublime_project_data = json.load(contents)
+                            except Exception:
+                                pass
+
+                        # If valid JSON
+                        if sublime_project_data is not None:
+                            # If "color_variables_files" key exists
+                            if "color_variables_files" in sublime_project_data:
+                                sublime_project_data_var = sublime_project_data["color_variables_files"]
+                                # If string
+                                if type(sublime_project_data_var) is str:
+                                    color_vars_files.append(sublime_project_data_var)
+                                # If list
+                                elif type(sublime_project_data_var) is list:
+                                    # For each in list
+                                    for i in sublime_project_data_var:
+                                        # Append to color_vars_files
+                                        color_vars_files.append(sublime_project_data_var[i])
 
                     for f in color_vars_files:
                         self.parse_vars_file(f)

--- a/ColorHighlighter.py
+++ b/ColorHighlighter.py
@@ -1269,9 +1269,9 @@ class VarExtractor:
                                     # If list
                                     elif type(sublime_project_data_var) is list:
                                         # For each in list
-                                        for i in sublime_project_data_var:
+                                        for f in sublime_project_data_var:
                                             # Append to color_vars_files
-                                            color_vars_files.append(sublime_project_data_var[i])
+                                            color_vars_files.append(f)
 
                     for f in color_vars_files:
                         self.parse_vars_file(f)


### PR DESCRIPTION
## Problem
People have reported that `color_variables_files` does not seem to work in [issue 296](https://github.com/Monnoroch/ColorHighlighter/issues/296).

Currently, `color_variables_files` is required to be in `.sublime-project` but if you don’t save and open directories as a “Sublime project,” then it won’t read the contents of `.sublime-project` and ColorHighlighter doesn’t work.

## Solution
I think it would be a good idea to also allow people to use a `.colorhighlighter` file that’s structured the same as `.sublime-project`.

Create a `.colorhighlighter` file in the root of your project and add the following in the file:
```
{
  "color_variables_files": [
    "/absolute/path/of/project/assets/_variables.scss"
  ]
}
```
That way it doesn’t require people to open directories as a “Sublime project” and will still work when you open directories from the command line using the `subl` command.

## Need Help
I managed to get my changes to work, but I am a Python n00b; therefore, will need help from more experienced devs to refactor and improve the code.