### PR TITLE
Add framework for using mkdocs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,0 +1,126 @@
+# ColorHighlighter
+
+[![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=C2L27SE4YDFAC)
+[![Package Control Downloads][pc-image]][pc-link]
+
+_ColorHighlighter is a plugin for the Sublime Text 2 and 3, which unobtrusively previews color values by underlaying the selected hex codes in different styles, coloring text or gutter icons. Also, plugin adds color picker, color format converter to easily modify colors._
+
+![Description](http://i.imgur.com/UPmEk09.png)
+
+![Description](http://i.imgur.com/kl4joGA.png)
+
+![Description](http://sametmax.com/wp-content/uploads/2013/04/hilight-color.gif)
+
+![Description](http://sametmax.com/wp-content/uploads/2013/04/color-picker.gif)
+
+## Installation
+
+- **_Recommended_** - Using [Sublime Package Control](https://packagecontrol.io "Sublime Package Control")
+    - ++ctrl+shift+p++ then select `Package Control: Install Package`
+    - install `Color Highlighter`
+- Alternatively, download the package from [GitHub](https://github.com/Monnoroch/ColorHighlighter "ColorHighlighter") into your `Packages` folder.
+- For gutter icons install [ImageMagick](http://www.imagemagick.org/). To configure ImageMagick, update `icon_factory.convert_command` plugin setting.
+
+## Color Highlighting styles
+
+There are three color highlighting styles: inline highlighting, underline blocks, and gutter icons.
+
+### Gutter icons
+
+To enable highlighting colors with gutter icons go to
+`Tools > Color Highlighter > Color Highlighters > Highlight colors in all text > Gutter icon style` and select `Circle` or `Square`.
+Highlighting colors with gutter icons requires ImageMagick to be installed (see the installation section).
+Going to `Tools > Color Highlighter > Color Highlighters > Highlight colors in all text > Gutter icon style` and selecting `None` will disable it.
+
+This mode can cause pauses when opening big files for the first time with "highlihgt everything" mode because
+the plugin needs to create icons for all newly encountered colors.
+
+### Underline blocks
+
+Highlighting colors with underline blocks will display colored blocks right under highlighted colors.
+These blocks cause text reflow.
+To enable highlighting colors with underline blocks go to
+`Tools > Color Highlighter > Color Highlighters > Highlight colors in all text` and click `Highlight colors with blocks`.
+Clicking on this setting again will disable it.
+
+### Inline highlighting
+
+Inline color highlighting itself has several styles.
+All of them require Color Scheme modification, so when this mode is enabled the view's color scheme is changed to a fake one,
+which is a copy of the real color scheme, but augmented with the plugin-specific definitions.
+To disable inline highlighting  go to
+`Tools > Color Highlighter > Color Highlighters > Highlight colors in all text > Inline highlighting style` and select `None`.
+
+##### Inline blocks
+
+Highlighting colors with inline blocks will display colored blocks right on top of highlighted colors.
+To enable highlighting colors with inline blocks go to
+`Tools > Color Highlighter > Color Highlighters > Highlight colors in all text > Inline highlighting style` and select `Filled`.
+
+##### Colored text
+
+Highlighting colors with colored text will make colors text be rendered with that color.
+To enable highlighting colors with colored text go to
+`Tools > Color Highlighter > Color Highlighters > Highlight colors in all text > Inline highlighting style` and select `Text`.
+
+##### Outline and underline styles
+
+If one wants color highlighting to be more subtle that one with inline blocks he can select one of
+`Outlined`, `Underlined solid`, `Underlined strippled`, `Underlined squiggly` styles in
+`Tools > Color Highlighter > Color Highlighters > Highlight colors in all text > Inline highlighting style` menu.
+
+## Color Highlighting modes
+
+#### Highlight everything
+
+In this mode the plugin parses the whole file and highlights all colors it can find.
+Highlighting style settings for that mode are in `Tools > Color Highlighter > Color Highlighters > Highlight colors in all text`.
+
+This mode can cause pauses when opening big files because the plugin needs to parse the whole file.
+
+#### Highlight selection
+
+In this mode the plugin highlights colors under the cursor. It supports multiple selections as well.
+Highlighting style settings for that mode are in `Tools > Color Highlighter > Color Highlighters > Highlight colors in selected text`.
+
+#### Highlight when hovering
+
+In this mode the plugin highlights colors when one hovers over them with the mouse cursor.
+Highlighting style settings for that mode are in `Tools > Color Highlighter > Color Highlighters > Highlight colors when hovering the cursor above them`.
+
+#### Combined
+
+These three modes can be combined in any possible way.
+The settings for all three modes are completely independent and can be configured all at once.
+For example, the default settings are to highlight all colors with gutter icons and with colored text,
+highlight selected colors with underline blocks and highlight colors one hovers over with inline blocks.
+
+## Color picker
+
+Just put the cursor (or multiple cursors) where you want the color and and select "Insert color with color picker"
+in context menu (or press ++ctrl+shift+c++).
+Select the color in a popup color picker and it will be inserted in place of all your cursors.
+If some of your cursors are in existing colors, these colors will be replaces with a newly selected one.
+
+## Color converter
+
+Just put the cursor (or multiple cursors) on the color code and select "Convert color to the next format" in context menu (or press ++ctrl+shift+comma++) or "Convert color to the previous format" in context menu (or press ++ctrl+shift+period++).
+This will convert colors under cursors between different supported color formats.
+
+## Variables highlighting
+
+THIS FEATURE CURRENTLY DOESN'T WORK.
+
+It was removed because it didn't work very well, was slow and buggy.
+Right now I'm in the process of searching for ways to implement it nicely, but it's not ready yet.
+I also plan to include color functions and native CSS variables into the release of this feature.
+Please be patient.
+
+**Donate**
+
+Thank you guys for all your support, I couldn't have done it wihout your contributions. Every little bit helps!
+
+[![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=C2L27SE4YDFAC)
+
+[pc-image]: https://img.shields.io/packagecontrol/dt/Color%20Highlighter.svg
+[pc-link]: https://packagecontrol.io/packages/Color%20Highlighter

--- a/docs/theme/extra.css
+++ b/docs/theme/extra.css
@@ -1,0 +1,70 @@
+.md-typeset .keys kbd::before,
+.md-typeset .keys kbd::after {
+    position: relative;
+    margin: 0;
+    color: #bdbdbd;
+    font-family: sans-serif;
+    -moz-osx-font-smoothing: initial;
+    -webkit-font-smoothing: initial;
+    font-weight: 400;
+}
+
+.md-typeset .keys span {
+    padding: 0 0.2rem;
+    color: #bdbdbd;
+}
+
+.md-typeset .keys .key-backspace::before {
+    padding-left: 0.2rem;
+    content: "←";
+}
+
+.md-typeset .keys .key-command::before {
+    padding-left: 0.2rem;
+    content: "⌘";
+}
+
+.md-typeset .keys .key-windows::before {
+    padding-left: 0.2rem;
+    content: "⊞";
+}
+
+.md-typeset .keys .key-caps-lock::before {
+    padding-left: 0.2rem;
+    content: "⇪";
+}
+
+.md-typeset .keys .key-control::before {
+    padding-left: 0.2rem;
+    content: "⌃";
+}
+
+.md-typeset .keys .key-meta::before {
+    padding-left: 0.2rem;
+    content: "◆";
+}
+
+.md-typeset .keys .key-shift::before {
+    padding-left: 0.2rem;
+    content: "⇧";
+}
+
+.md-typeset .keys .key-option::before {
+    padding-left: 0.2rem;
+    content: "⌥";
+}
+
+.md-typeset .keys .key-tab::after {
+    padding-left: 0.2rem;
+    content: "↹";
+}
+
+.md-typeset .keys .key-num-enter::after {
+    padding-left: 0.2rem;
+    content: "↵";
+}
+
+.md-typeset .keys .key-enter::after {
+    padding-left: 0.2rem;
+    content: "↩";
+}

--- a/docs/theme/partials/footer.html
+++ b/docs/theme/partials/footer.html
@@ -1,0 +1,60 @@
+{% import "partials/language.html" as lang %}
+<footer class="md-footer">
+  {% if page.previous_page or page.next_page %}
+    <div class="md-footer-nav">
+      <nav class="md-footer-nav__inner md-grid">
+        {% if page.previous_page %}
+          <a href="{{ page.previous_page.url }}" title="{{ page.previous_page.title }}" class="md-flex md-footer-nav__link md-footer-nav__link--prev" rel="prev">
+            <div class="md-flex__cell md-flex__cell--shrink">
+              <i class="md-icon md-icon--arrow-back md-footer-nav__button"></i>
+            </div>
+            <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title">
+              <span class="md-flex__ellipsis">
+                <span class="md-footer-nav__direction">
+                  {{ lang.t('footer.previous') }}
+                </span>
+                {{ page.previous_page.title }}
+              </span>
+            </div>
+          </a>
+        {% endif %}
+        {% if page.next_page %}
+          <a href="{{ page.next_page.url }}" title="{{ page.next_page.title }}" class="md-flex md-footer-nav__link md-footer-nav__link--next" rel="next">
+            <div class="md-flex__cell md-flex__cell--stretch md-footer-nav__title">
+              <span class="md-flex__ellipsis">
+                <span class="md-footer-nav__direction">
+                  {{ lang.t('footer.next') }}
+                </span>
+                {{ page.next_page.title }}
+              </span>
+            </div>
+            <div class="md-flex__cell md-flex__cell--shrink">
+              <i class="md-icon md-icon--arrow-forward md-footer-nav__button"></i>
+            </div>
+          </a>
+        {% endif %}
+      </nav>
+    </div>
+  {% endif %}
+  <div class="md-footer-meta md-typeset">
+    <div class="md-footer-meta__inner md-grid">
+      <div class="md-footer-copyright">
+        {% if config.copyright %}
+          <div class="md-footer-copyright__highlight">
+            {{ config.copyright }}
+          </div>
+        {% endif %}
+        powered by
+        <a href="http://www.mkdocs.org" title="MkDocs">MkDocs</a>
+        and
+        <a href="http://squidfunk.github.io/mkdocs-material/" title="Material for MkDocs">
+          Material for MkDocs</a>
+        with emoji provided free by
+        <a href="http://www.emojione.com">EmojiOne</a>
+      </div>
+      {% block social %}
+        {% include "partials/social.html" %}
+      {% endblock %}
+    </div>
+  </div>
+</footer>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ markdown_extensions:
       nbsp: true
   - pymdownx.tasklist:
       custom_checkbox: true
+  # TODO: Setup common includes in _snippets like links etc.
   # - pymdownx.snippets:
   #     base_path: docs/src/_snippets
   - pymdownx.keys:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -29,7 +29,7 @@ markdown_extensions:
   - pymdownx.inlinehilite:
   - pymdownx.magiclink:
       repo_url_shortener: true
-      base_repo_url: https://github.com/facelessuser/ColorHighlighter
+      base_repo_url: https://github.com/Monnoroch/ColorHighlighter
   - pymdownx.tilde:
   - pymdownx.caret:
   - pymdownx.smartsymbols:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,61 @@
+site_name: ColorHighlighter Documentation
+site_url: https://Monnoroch.github.io/ColorHighlighter
+repo_url: https://github.com/Monnoroch/ColorHighlighter
+edit_uri: tree/master/docs/src
+site_description: A color highlighting plugin for Sublime Text 2 and 3.
+
+pages:
+  - ColorHighlighter: index.md
+
+theme: material
+docs_dir: docs/src
+theme_dir: docs/theme
+
+markdown_extensions:
+  - markdown.extensions.toc:
+      slugify: !!python/name:pymdownx.slugs.gfm
+  - markdown.extensions.admonition:
+  - markdown.extensions.smarty:
+      smart_quotes: false
+  - pymdownx.betterem:
+  - markdown.extensions.attr_list:
+  - markdown.extensions.def_list:
+  - markdown.extensions.tables:
+  - markdown.extensions.abbr:
+  - pymdownx.extrarawhtml:
+  - pymdownx.superfences:
+  - pymdownx.highlight:
+      css_class: codehilite
+  - pymdownx.inlinehilite:
+  - pymdownx.magiclink:
+      repo_url_shortener: true
+      base_repo_url: https://github.com/facelessuser/ColorHighlighter
+  - pymdownx.tilde:
+  - pymdownx.caret:
+  - pymdownx.smartsymbols:
+  - pymdownx.emoji:
+      emoji_generator: !!python/name:pymdownx.emoji.to_png
+  - pymdownx.escapeall:
+      hardbreak: true
+      nbsp: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  # - pymdownx.snippets:
+  #     base_path: docs/src/_snippets
+  - pymdownx.keys:
+      separator: "\uff0b"
+  - pymdownx.details:
+
+extra:
+  palette:
+    primary: blue
+    accent: blue
+  font:
+    text: Roboto
+    code: Roboto Mono
+  social:
+    - type: github
+      link: https://github.com/Monnoroch
+
+extra_css:
+  - extra.css


### PR DESCRIPTION
As discussed in https://github.com/facelessuser/ColorHelper/issues/95, I threw together documents site for you.

![screenshot 2017-09-30 20 36 13](https://user-images.githubusercontent.com/1055125/31051248-c665e32c-a620-11e7-9206-1d71d7862473.png)

What needs to be done first is to setup Github Pages branch called: `gh-pages`.

I didn't setup auto deployment on tagging as this repo is not using Travis or some other CI system.  If we want to go in that direction we can, but for now, I'm keeping it simple.

You would need to `pip install mkdocs` and `pip install mkdocs-material` to start using mkdocs locally.  To live preview the site: `mkdocs serve`.  To deploy to `gh-pages`: `mkdocs gh-deploy --clean`.

I setup a number of extensions in mkdocs.yml that I use, but feel free to remove or add whatever you want.  Documents source are found in `docs/src.

Some overrides and additional CSS is provided in `docs/theme`.  Mainly, I configured an emoji plugin that allows you to insert emoji via short names `:smile:` etc.  Much like Github, but it is using [EmojiOne](https://www.emojione.com/emoji/v3) emojis and short names, so I've overridden the footer to mention that emojis are provided by EmojiOne (needed per EmojiOne's license).  If you have no intentions of using emojis, that can be removed and the extension removed as well.  Also I added some styling for `kbd` keys as I also included a kbd extension.

Anyways, feel free to ask questions or make suggestions.  Obviously I didn't bother breaking up or organizing the documents, I simply copied and pasted the readme (with small modifications) as the intentions of this is just to provide the document framework.